### PR TITLE
feat: enforce 4-chain diagnostics and add reference corpus builder

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,9 +62,75 @@ reference is stable and diagnostic-friendly.
 
 Diagnostics use rank-normalized split R-hat and bulk/tail ESS with stdlib-only
 implementations to keep dependencies light.
+These diagnostics require at least 4 independent chains by default; use
+explicit override paths (for example `convert --force`) only when you
+intentionally want single-chain conversion with diagnostic metrics marked `nan`.
 
 For integration tests, you can optionally generate missing reference draws by
 setting `MCMC_REF_GENERATE=1` and (optionally) `MCMC_REF_GENERATE_MODEL=...`.
+
+## Build Canonical References
+
+Use this when you want a pre-built corpus other libraries can validate against.
+
+```bash
+# default source: ~/.posteriordb/posterior_database/reference_posteriors/draws/draws
+# default output: ~/.mcmc-ref/{draws,meta}
+uv run --extra dev python scripts/build_references.py
+```
+
+The builder converts every `*.json.zip` file and enforces quality checks
+(`nchains_is_gte_4`, `rhat_below_1_01`, ESS and draw-count checks). If any model
+fails, it exits non-zero and prints the failing models.
+
+Useful options:
+
+```bash
+# convert only selected models
+uv run --extra dev python scripts/build_references.py \
+  --models eight_schools-eight_schools_noncentered,diamonds-diamonds
+
+# override source and output paths
+uv run --extra dev python scripts/build_references.py \
+  --source-dir ~/.posteriordb/posterior_database/reference_posteriors/draws/draws \
+  --output-root /path/to/reference-corpus
+```
+
+If you install `mcmc-ref` as a package, the equivalent command is
+`mcmc-ref-build-references`.
+
+## Validate From Another Library
+
+Point your tests at the reference corpus and compare your sampler output.
+
+1. Build or download a corpus containing `draws/*.draws.parquet` and `meta/*.meta.json`.
+2. Set `MCMC_REF_LOCAL_ROOT` to that corpus root in your test environment.
+3. Run comparisons against one or more models.
+
+CLI flow:
+
+```bash
+export MCMC_REF_LOCAL_ROOT=/path/to/reference-corpus
+mcmc-ref compare eight_schools-eight_schools_noncentered --actual my_draws.csv --tolerance 0.15
+```
+
+Python flow:
+
+```python
+import os
+from mcmc_ref import reference
+
+os.environ["MCMC_REF_LOCAL_ROOT"] = "/path/to/reference-corpus"
+result = reference.compare(
+    "eight_schools-eight_schools_noncentered",
+    actual={"mu": mu_draws, "tau": tau_draws},
+    tolerance=0.15,
+)
+assert result.passed, result.failures
+```
+
+`actual` can come from your sampler output after mapping parameter names to the
+reference naming convention.
 
 ## Origin Story:
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,6 +15,7 @@ dev = ["pytest>=8.2", "ruff>=0.5.0", "ty>=0.0.1"]
 
 [project.scripts]
 mcmc-ref = "mcmc_ref.cli:main"
+mcmc-ref-build-references = "mcmc_ref.build_references:main"
 
 [tool.ruff]
 line-length = 100

--- a/scripts/build_references.py
+++ b/scripts/build_references.py
@@ -1,0 +1,19 @@
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+
+def main() -> None:
+    root = Path(__file__).resolve().parents[1]
+    src = root / "src"
+    if str(src) not in sys.path:
+        sys.path.insert(0, str(src))
+
+    from mcmc_ref.build_references import main as build_main
+
+    build_main()
+
+
+if __name__ == "__main__":
+    main()

--- a/src/mcmc_ref/build_references.py
+++ b/src/mcmc_ref/build_references.py
@@ -1,0 +1,124 @@
+"""Build a local reference corpus from posteriordb json.zip draw files."""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from dataclasses import dataclass
+from pathlib import Path
+
+import click
+
+from . import convert
+
+DEFAULT_POSTERIORDB_DRAWS = (
+    Path.home() / ".posteriordb" / "posterior_database" / "reference_posteriors" / "draws" / "draws"
+)
+
+
+@dataclass(frozen=True)
+class BuildFailure:
+    model: str
+    input_path: Path
+    error: str
+
+
+@dataclass(frozen=True)
+class BuildResult:
+    total: int
+    converted: int
+    failures: list[BuildFailure]
+    output_root: Path
+
+
+def build_references(
+    source_dir: Path,
+    output_root: Path,
+    *,
+    models: Sequence[str] | None = None,
+    force: bool = False,
+) -> BuildResult:
+    source_dir = Path(source_dir)
+    output_root = Path(output_root)
+    draws_dir = output_root / "draws"
+    meta_dir = output_root / "meta"
+    draws_dir.mkdir(parents=True, exist_ok=True)
+    meta_dir.mkdir(parents=True, exist_ok=True)
+
+    files = sorted(source_dir.glob("*.json.zip"))
+    if models is not None:
+        requested = set(models)
+        files = [path for path in files if path.stem.replace(".json", "") in requested]
+
+    failures: list[BuildFailure] = []
+    converted = 0
+    for input_path in files:
+        model = input_path.stem.replace(".json", "")
+        try:
+            convert.convert_file(
+                input_path=input_path,
+                name=model,
+                out_draws_dir=draws_dir,
+                out_meta_dir=meta_dir,
+                force=force,
+            )
+            converted += 1
+        except Exception as exc:
+            failures.append(BuildFailure(model=model, input_path=input_path, error=str(exc)))
+
+    return BuildResult(
+        total=len(files),
+        converted=converted,
+        failures=failures,
+        output_root=output_root,
+    )
+
+
+@click.command("build-references")
+@click.option(
+    "--source-dir",
+    type=click.Path(path_type=Path),
+    default=DEFAULT_POSTERIORDB_DRAWS,
+    show_default=True,
+    help="Directory containing posteriordb *.json.zip draw files.",
+)
+@click.option(
+    "--output-root",
+    type=click.Path(path_type=Path),
+    default=Path.home() / ".mcmc-ref",
+    show_default=True,
+    help="Reference corpus root with draws/ and meta/ subdirectories.",
+)
+@click.option(
+    "--models",
+    default=None,
+    help="Optional comma-separated model list (e.g. eight_schools-eight_schools_noncentered).",
+)
+@click.option(
+    "--force",
+    is_flag=True,
+    help="Allow conversion when quality checks fail (not recommended for canonical benchmarks).",
+)
+def main(source_dir: Path, output_root: Path, models: str | None, force: bool) -> None:
+    """Convert all posteriordb draw archives to a local mcmc-ref corpus."""
+    if not source_dir.exists():
+        raise SystemExit(f"source directory not found: {source_dir}")
+    model_list = models.split(",") if models else None
+    result = build_references(
+        source_dir=source_dir,
+        output_root=output_root,
+        models=model_list,
+        force=force,
+    )
+
+    click.echo(f"source: {source_dir}")
+    click.echo(f"output: {result.output_root}")
+    click.echo(f"converted: {result.converted}/{result.total}")
+    if result.failures:
+        click.echo("failures:")
+        for failure in result.failures:
+            click.echo(f"- {failure.model}: {failure.error}")
+        raise SystemExit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/unit/test_build_references.py
+++ b/tests/unit/test_build_references.py
@@ -1,0 +1,69 @@
+from __future__ import annotations
+
+import json
+import zipfile
+from pathlib import Path
+
+from mcmc_ref.build_references import build_references
+
+
+def _write_posteriordb_json_zip(path: Path, chains: int = 4, draws: int = 4) -> None:
+    payload: list[dict[str, list[float]]] = []
+    for chain_idx in range(chains):
+        mu = [1.0 + chain_idx * 0.01 + draw_idx * 0.1 for draw_idx in range(draws)]
+        tau = [2.0 + chain_idx * 0.01 + draw_idx * 0.1 for draw_idx in range(draws)]
+        payload.append({"mu": mu, "tau": tau})
+
+    with zipfile.ZipFile(path, "w", compression=zipfile.ZIP_DEFLATED) as zf:
+        zf.writestr(path.stem.replace(".json", "") + ".json", json.dumps(payload))
+
+
+def test_build_references_converts_all_models(tmp_path: Path) -> None:
+    source_dir = tmp_path / "source"
+    output_root = tmp_path / "out"
+    source_dir.mkdir()
+    _write_posteriordb_json_zip(source_dir / "model_a-model_a.json.zip")
+    _write_posteriordb_json_zip(source_dir / "model_b-model_b.json.zip")
+
+    result = build_references(source_dir=source_dir, output_root=output_root, force=True)
+
+    assert result.total == 2
+    assert result.converted == 2
+    assert not result.failures
+    assert (output_root / "draws" / "model_a-model_a.draws.parquet").exists()
+    assert (output_root / "meta" / "model_b-model_b.meta.json").exists()
+
+
+def test_build_references_filters_models(tmp_path: Path) -> None:
+    source_dir = tmp_path / "source"
+    output_root = tmp_path / "out"
+    source_dir.mkdir()
+    _write_posteriordb_json_zip(source_dir / "model_a-model_a.json.zip")
+    _write_posteriordb_json_zip(source_dir / "model_b-model_b.json.zip")
+
+    result = build_references(
+        source_dir=source_dir,
+        output_root=output_root,
+        models=["model_b-model_b"],
+        force=True,
+    )
+
+    assert result.total == 1
+    assert result.converted == 1
+    assert not result.failures
+    assert not (output_root / "draws" / "model_a-model_a.draws.parquet").exists()
+    assert (output_root / "draws" / "model_b-model_b.draws.parquet").exists()
+
+
+def test_build_references_reports_strict_check_failures(tmp_path: Path) -> None:
+    source_dir = tmp_path / "source"
+    output_root = tmp_path / "out"
+    source_dir.mkdir()
+    _write_posteriordb_json_zip(source_dir / "model_a-model_a.json.zip", chains=1)
+
+    result = build_references(source_dir=source_dir, output_root=output_root)
+
+    assert result.total == 1
+    assert result.converted == 0
+    assert len(result.failures) == 1
+    assert "at least 4 chains" in result.failures[0].error

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -12,9 +12,9 @@ from mcmc_ref.cli import main
 def _write_parquet(path: Path) -> None:
     table = pa.table(
         {
-            "chain": pa.array([0, 0, 1, 1], type=pa.int32()),
-            "draw": pa.array([0, 1, 0, 1], type=pa.int32()),
-            "mu": pa.array([1.0, 2.0, 1.5, 2.5], type=pa.float64()),
+            "chain": pa.array([0, 0, 1, 1, 2, 2, 3, 3], type=pa.int32()),
+            "draw": pa.array([0, 1, 0, 1, 0, 1, 0, 1], type=pa.int32()),
+            "mu": pa.array([1.0, 2.0, 1.5, 2.5, 1.0, 2.0, 1.5, 2.5], type=pa.float64()),
         }
     )
     pq.write_table(table, path)
@@ -75,13 +75,7 @@ def test_cli_compare_passes(tmp_path: Path, monkeypatch) -> None:
     (meta_dir / "example.meta.json").write_text("{}")
 
     actual_csv = tmp_path / "actual.csv"
-    actual_csv.write_text(
-        "chain,draw,mu\n"
-        "0,0,1.0\n"
-        "0,1,2.0\n"
-        "1,0,1.5\n"
-        "1,1,2.5\n"
-    )
+    actual_csv.write_text("chain,draw,mu\n0,0,1.0\n0,1,2.0\n1,0,1.5\n1,1,2.5\n")
 
     monkeypatch.setenv("MCMC_REF_LOCAL_ROOT", str(tmp_path))
 

--- a/tests/unit/test_convert.py
+++ b/tests/unit/test_convert.py
@@ -1,6 +1,9 @@
 from __future__ import annotations
 
+import math
 from pathlib import Path
+
+import pytest
 
 from mcmc_ref import convert
 
@@ -20,3 +23,40 @@ def test_convert_csv(tmp_path: Path) -> None:
 
     assert (out_draws / "example.draws.parquet").exists()
     assert (out_meta / "example.meta.json").exists()
+
+
+def test_convert_rejects_single_chain_by_default(tmp_path: Path) -> None:
+    csv_path = tmp_path / "single_chain.csv"
+    csv_path.write_text("chain,draw,mu\n0,0,1.0\n0,1,1.1\n0,2,1.2\n0,3,1.3\n")
+
+    out_draws = tmp_path / "draws"
+    out_meta = tmp_path / "meta"
+    out_draws.mkdir()
+    out_meta.mkdir()
+
+    with pytest.raises(ValueError, match="at least 4 chains"):
+        convert.convert_file(
+            csv_path, name="single_chain", out_draws_dir=out_draws, out_meta_dir=out_meta
+        )
+
+
+def test_convert_allows_single_chain_with_force_override(tmp_path: Path) -> None:
+    csv_path = tmp_path / "single_chain.csv"
+    csv_path.write_text("chain,draw,mu\n0,0,1.0\n0,1,1.1\n0,2,1.2\n0,3,1.3\n")
+
+    out_draws = tmp_path / "draws"
+    out_meta = tmp_path / "meta"
+    out_draws.mkdir()
+    out_meta.mkdir()
+
+    result = convert.convert_file(
+        csv_path,
+        name="single_chain",
+        out_draws_dir=out_draws,
+        out_meta_dir=out_meta,
+        force=True,
+    )
+
+    assert (out_draws / "single_chain.draws.parquet").exists()
+    assert (out_meta / "single_chain.meta.json").exists()
+    assert math.isnan(result.meta["diagnostics"]["mu"]["rhat"])

--- a/tests/unit/test_diagnostics.py
+++ b/tests/unit/test_diagnostics.py
@@ -1,10 +1,16 @@
 from __future__ import annotations
 
+import math
+
+import pytest
+
 from mcmc_ref.diagnostics import ess_bulk, split_rhat
 
 
 def test_split_rhat_identical_chains() -> None:
     chains = [
+        [1.0, 1.0, 1.0, 1.0],
+        [1.0, 1.0, 1.0, 1.0],
         [1.0, 1.0, 1.0, 1.0],
         [1.0, 1.0, 1.0, 1.0],
     ]
@@ -16,6 +22,8 @@ def test_ess_positive() -> None:
     chains = [
         [1.0, 2.0, 3.0, 4.0],
         [1.1, 2.1, 3.1, 4.1],
+        [0.9, 1.9, 2.9, 3.9],
+        [1.05, 2.05, 3.05, 4.05],
     ]
     ess = ess_bulk(chains)
     assert ess > 0
@@ -25,6 +33,26 @@ def test_split_rhat_detects_scale_diff() -> None:
     chains = [
         [0.0, 0.0, 0.0, 0.0],
         [10.0, 10.0, 10.0, 10.0],
+        [0.0, 0.0, 0.0, 0.0],
+        [10.0, 10.0, 10.0, 10.0],
     ]
     rhat = split_rhat(chains)
     assert rhat > 1.1
+
+
+def test_split_rhat_requires_four_chains_by_default() -> None:
+    chains = [[1.0, 2.0, 3.0, 4.0], [1.1, 2.1, 3.1, 4.1]]
+    with pytest.raises(ValueError, match="at least 4 chains"):
+        split_rhat(chains)
+
+
+def test_split_rhat_allows_single_chain_when_explicitly_overridden() -> None:
+    chains = [[1.0, 2.0, 3.0, 4.0]]
+    rhat = split_rhat(chains, min_chains=1)
+    assert math.isnan(rhat)
+
+
+def test_ess_bulk_requires_four_chains_by_default() -> None:
+    chains = [[1.0, 2.0, 3.0, 4.0], [1.1, 2.1, 3.1, 4.1]]
+    with pytest.raises(ValueError, match="at least 4 chains"):
+        ess_bulk(chains)

--- a/tests/unit/test_reference.py
+++ b/tests/unit/test_reference.py
@@ -13,9 +13,9 @@ from mcmc_ref.store import DataStore
 def _write_parquet(path: Path) -> None:
     table = pa.table(
         {
-            "chain": pa.array([0, 0, 1, 1], type=pa.int32()),
-            "draw": pa.array([0, 1, 0, 1], type=pa.int32()),
-            "mu": pa.array([1.0, 2.0, 1.5, 2.5], type=pa.float64()),
+            "chain": pa.array([0, 0, 1, 1, 2, 2, 3, 3], type=pa.int32()),
+            "draw": pa.array([0, 1, 0, 1, 0, 1, 0, 1], type=pa.int32()),
+            "mu": pa.array([1.0, 2.0, 1.5, 2.5, 1.0, 2.0, 1.5, 2.5], type=pa.float64()),
         }
     )
     pq.write_table(table, path)


### PR DESCRIPTION
Summary
- enforce a 4-chain default for R-hat/ESS diagnostics, with explicit override paths for forced conversion
- add a reference-corpus builder module plus a repo script wrapper
- add tests for diagnostics behavior and reference builder flow
- document canonical reference-build and cross-library validation flows in README

Testing
- uv run --extra dev ruff check .
- uv run --extra dev ty check .
- uv run --extra dev pytest -q